### PR TITLE
Init bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "download-git-repo": "^1.0.2",
     "fs": "0.0.1-security",
     "inquirer": "^6.0.0",
+    "mkdirp": "^0.5.1",
     "mocha": "^5.2.0",
     "repl": "^0.1.3",
     "solhint": "^1.2.1"


### PR DESCRIPTION
Previously it was not letting me `titan init my-project` without 1. an aion node running 2. `$PWD/titanrc.js` already existing.

Ideas in this PR:
+ allow init without node up
+ cross platform path fixes
+ `mkdirp` simplification
+ download pack simplification